### PR TITLE
Configure Jekyll site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 3.9"
+
+group :jekyll_plugins do
+  gem "github-pages"
+  gem "jekyll-feed"
+  gem "jekyll-mermaid"
+end

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# vkgeorgia.github.io
+
+This repository hosts the source for the personal site of Valerii Korobeinikov.
+
+## Ruby and Jekyll setup
+
+1. Install [Ruby](https://www.ruby-lang.org/en/documentation/installation/) and
+   [Bundler](https://bundler.io/).
+2. Install the dependencies:
+   ```bash
+   bundle install
+   ```
+3. Build or serve the site locally:
+   ```bash
+   bundle exec jekyll serve
+   ```
+   The site will be available at <http://localhost:4000>.
+
+GitHub Pages will build the site using Jekyll based on the configuration in
+`_config.yml`.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,12 @@
+title: "Valerii Korobeinikov"
+description: "Enterprise Architect and IT Consultant"
+url: "https://vkgeorgia.github.io"
+baseurl: ""
+lang: en
+languages:
+  - en
+  - ru
+
+plugins:
+  - jekyll-feed
+  - jekyll-mermaid


### PR DESCRIPTION
## Summary
- add Gemfile with github-pages and Jekyll plugins
- configure site metadata and plugins in _config.yml
- document Ruby/Jekyll setup and remove `.nojekyll`

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a36c0e0ed483238ed99aa17221ad22