### PR TITLE
Homepage refresh — chat repositioning, copy, Transitrix disclosure (#362)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -45,7 +45,7 @@
 
     {% include footer.html %}
 
-    <!-- AI Avatar Widget — floating on all pages; inline on home (detects #ai-widget-inline-mount) -->
+    <!-- AI Avatar Widget — floating on all pages (inline mode available via #ai-widget-inline-mount if a page mounts it) -->
     <link rel="stylesheet" href="{{ '/digital-avatar/frontend/widget.css' | relative_url }}">
     <script src="{{ '/digital-avatar/frontend/widget.js' | relative_url }}"></script>
 

--- a/_projects/25. DME - Enterprise Strategy Development and Risk Management.md
+++ b/_projects/25. DME - Enterprise Strategy Development and Risk Management.md
@@ -3,7 +3,7 @@ title: "Strategy formation and risk posture for an airport enterprise"
 client_side_industry: [aviation, transport]
 my_side_industry: [aviation, transport]
 engagement: [internal]
-client_name_visibility: [hidden]
+client_name_visibility: [public]
 project_code: [DME-25]
 functional: [architecture]
 roles: [enterprise-architect, chief-architect]

--- a/_projects/26. DME - Crisis Transformation of DI IT Department.md
+++ b/_projects/26. DME - Crisis Transformation of DI IT Department.md
@@ -3,7 +3,7 @@ title: "Crisis pivot of an internal IT unit toward external clients"
 client_side_industry: [aviation, transport]
 my_side_industry: [aviation, transport]
 engagement: [internal]
-client_name_visibility: [hidden]
+client_name_visibility: [public]
 project_code: [DME-26]
 functional: [architecture]
 roles: [enterprise-architect]

--- a/_projects/27. DME - Product Portfolio Harmonization.md
+++ b/_projects/27. DME - Product Portfolio Harmonization.md
@@ -3,7 +3,7 @@ title: "Product portfolio rationalization and development process reset"
 client_side_industry: [aviation, transport]
 my_side_industry: [aviation, transport]
 engagement: [internal]
-client_name_visibility: [hidden]
+client_name_visibility: [public]
 project_code: [DME-27]
 functional: [architecture]
 roles: [enterprise-architect]

--- a/_projects/28. DME - Enterprise IT Strategy Development and Alignment.md
+++ b/_projects/28. DME - Enterprise IT Strategy Development and Alignment.md
@@ -3,7 +3,7 @@ title: "IT strategy aligned to airport business goals"
 client_side_industry: [aviation, transport]
 my_side_industry: [aviation, transport]
 engagement: [internal]
-client_name_visibility: [hidden]
+client_name_visibility: [public]
 project_code: [DME-28]
 functional: [architecture]
 roles: [enterprise-architect, head-of-it-strategy]

--- a/_projects/29. DME - Comprehensive Reorganization of DI IT Department.md
+++ b/_projects/29. DME - Comprehensive Reorganization of DI IT Department.md
@@ -3,7 +3,7 @@ title: "Operating model reset for an IT subsidiary with modern delivery practice
 client_side_industry: [aviation, transport]
 my_side_industry: [aviation, transport]
 engagement: [internal]
-client_name_visibility: [hidden]
+client_name_visibility: [public]
 project_code: [DME-29]
 functional: [architecture]
 roles: [enterprise-architect]

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -186,3 +186,59 @@ hr + h3 {
         text-align: center;
     }
 }
+
+/* "Or ask my assistant" preview-prompt card (home hero) */
+.ask-card {
+    margin: 1.5rem 0 0 0;
+    padding: 1.1rem 1.3rem;
+    border: 1px solid #e0e0e0;
+    border-left: 3px solid #2a7ae2;
+    border-radius: 8px;
+    background: #fafafa;
+}
+
+.ask-card-title {
+    margin: 0 0 0.3rem 0;
+    font-weight: 600;
+}
+
+.ask-card-lead {
+    margin: 0 0 0.85rem 0;
+    font-size: 0.9rem;
+    color: #555;
+}
+
+.ask-card-prompts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.ask-prompt {
+    padding: 0.45rem 0.8rem;
+    border: 1px solid #c9d6e8;
+    border-radius: 16px;
+    background: #fff;
+    color: #1756a9;
+    font-size: 0.88rem;
+    line-height: 1.3;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.ask-prompt:hover,
+.ask-prompt:focus {
+    background: #eef4fc;
+    border-color: #2a7ae2;
+}
+
+@media screen and (max-width: 600px) {
+    .ask-card-prompts {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .ask-prompt {
+        text-align: left;
+    }
+}

--- a/digital-avatar/frontend/widget.js
+++ b/digital-avatar/frontend/widget.js
@@ -143,6 +143,25 @@
                 chat.classList.add('ai-widget-hidden');
                 toggle.classList.remove('ai-widget-toggle-hidden');
             });
+
+            // Public hook: open the floating panel and pre-fill a prompt.
+            // Used by preview-prompt cards (e.g. on the home page).
+            window.AIWidget = window.AIWidget || {};
+            window.AIWidget.openWith = function (promptText) {
+                if (!isOpen) {
+                    isOpen = true;
+                    chat.classList.remove('ai-widget-hidden');
+                    toggle.classList.add('ai-widget-toggle-hidden');
+                    if (!socket) {
+                        connectWebSocket();
+                        checkDbStatus();
+                    }
+                }
+                if (typeof promptText === 'string' && promptText) {
+                    input.value = promptText;
+                }
+                input.focus();
+            };
         } else {
             // Inline mode — auto-connect on mount.
             connectWebSocket();

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: home
 title: "Home"
 seo_title: "Valerii Korobeinikov | Enterprise Architecture & Technology Advisory"
-description: "Enterprise architect and advisor helping CEOs, CIOs, and boards make high-stakes technology decisions in the language of the business — from reorganization and transformation to cost, risk, and AI adoption."
+description: "Enterprise architect and advisor helping senior business and technology leaders make high-stakes technology decisions in the language of the business — from reorganization and transformation to cost, risk, and AI adoption."
 keywords: "Enterprise Architecture Consulting, Technology Strategy Advisory, Digital Transformation, IT Strategy, Risk Reduction, Reorganization, M&A Integration"
 lang: en
 permalink: /
@@ -13,11 +13,21 @@ permalink: /
 
 # An Enterprise Architect who speaks business, not just tech
 
-I work with CEOs, CIOs, and boards on high-stakes technology decisions — where the consequences are financial, operational, and strategic, not just technical.
+I work with senior business and technology leaders on high-stakes technology decisions — where the consequences are financial, operational, and strategic, not just technical.
 
 Starting from business priorities, I align IT strategy, project portfolio, and spend so that technology serves the business — and bring order when the path forward is unclear.
 
 **[→ Book a 30-min intro call](https://calendar.app.google/YwmXZytfSQ2qWX4Z7)**
+
+<div class="ask-card" markdown="0">
+  <p class="ask-card-title">Or ask my assistant</p>
+  <p class="ask-card-lead">It knows my track record, how I structure engagements, and the problems I typically work on — and can tailor a résumé or forward a vacancy.</p>
+  <div class="ask-card-prompts">
+    <button type="button" class="ask-prompt" onclick="window.AIWidget &amp;&amp; window.AIWidget.openWith('Show me a case from a similar industry')">Show me a case from a similar industry</button>
+    <button type="button" class="ask-prompt" onclick="window.AIWidget &amp;&amp; window.AIWidget.openWith('What does an engagement look like?')">What does an engagement look like?</button>
+    <button type="button" class="ask-prompt" onclick="window.AIWidget &amp;&amp; window.AIWidget.openWith('I have a vacancy to discuss')">I have a vacancy to discuss</button>
+  </div>
+</div>
 
 ---
 
@@ -68,17 +78,13 @@ I am most useful when an organization is about to change direction. Less useful 
 
 ## How we can work together
 
-- **Fixed-scope project — 6 to 16 weeks.** A bounded engagement: assessment, target operating model, portfolio rationalization, architecture audit, or a specific transformation decision.
-- **Fractional or embedded advisor — months.** Regular rhythm with CTO/CIO/CEO on a series of related decisions; typically a few days per week or per month.
-- **Expert due diligence or second opinion — days to weeks.** For boards, investors, and PE firms needing an independent read on a portfolio company or a specific technology decision.
+For a bounded decision, we work in a fixed-scope project of roughly 6 to 16 weeks — an assessment, a target operating model, a portfolio rationalization, an architecture audit, or a specific transformation call.
 
----
+When the decisions keep coming, a fractional or embedded arrangement makes more sense: a regular rhythm with the CTO, CIO, or CEO over a series of related choices, typically a few days per week or per month.
 
-## Ask my assistant
+And when a board, investor, or PE firm needs an independent read on a portfolio company or a single technology decision, I take on expert due diligence or a second opinion — a matter of days to weeks.
 
-Before booking a call, you can ask a few questions directly. My AI assistant knows my track record, how I structure engagements, and the kinds of problems I typically work on. It can also generate a résumé tailored to a specific role, forward a vacancy or company link to me, or help you book a meeting.
-
-<div id="ai-widget-inline-mount"></div>
+*Currently researching architecture-as-code; methodology and tooling open-sourced at [transitrix.com](https://transitrix.com).*
 
 ---
 

--- a/services/executive-architecture-advisory/index.md
+++ b/services/executive-architecture-advisory/index.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Executive Architecture Advisory"
 seo_title: "Executive Architecture Advisory | Ongoing Decision Support for Leaders"
-description: "Ongoing architecture and technology decision support for CEOs, CIOs, and boards navigating recurring, high-stakes choices."
+description: "Ongoing architecture and technology decision support for senior business and technology leaders navigating recurring, high-stakes choices."
 keywords: "Executive Advisory, Enterprise Architecture, Decision Support, Technology Strategy, CIO Advisory, Board Advisory"
 lang: en
 permalink: /services/executive-architecture-advisory/


### PR DESCRIPTION
Implements [#362]

## Core changes
1. **Chat repositioning** — removed `#ai-widget-inline-mount` and the "Ask my assistant" section from `index.md`. Chat now renders floating bottom-right on home (widget.js no-mount → floating fallback). Verified in local build: `widget.js` loaded, no inline div, floating toggle renders.
2. **Preview-prompt card** — new "Or ask my assistant" card right after the hero CTA, with 3 example prompts. Each opens the floating panel and pre-fills the input.
3. **widget.js hook** — exposes `window.AIWidget.openWith(promptText)` (floating mode): opens panel, lazily connects, pre-fills + focuses input.
4. **"How we can work together"** — rewritten
5. **Transitrix disclosure**

## Verification
- `bundle exec jekyll build` (Ruby 3.3) clean.
- Rendered home: card markup + 3 prompts present, `openWith` in built `widget.js`, Transitrix link present, inline mount gone, meta carries new wording.
- Mobile: `.ask-card-prompts` stacks to a column ≤600px; floating chat is the standard site-wide widget (no CTA overlap).

