### PR TITLE
Align case visibility flags and bodies with the canonical source

### DIFF
--- a/_projects/05. OilPC - OILPC-KSBR.md
+++ b/_projects/05. OilPC - OILPC-KSBR.md
@@ -4,7 +4,7 @@ client_side_industry: [oil-gas, retail]
 my_side_industry: [it-services, finance]
 delivery_model: [managed-service, platform-operator, service-outsourcing]
 engagement: [external]
-client_name_visibility: [public]
+client_name_visibility: [hidden]
 project_code: [OILPC-KSBR]
 functional: [loyalty]
 roles: [business-analyst, solution-architect, project-manager]
@@ -12,7 +12,7 @@ roles: [business-analyst, solution-architect, project-manager]
 # Corporate cashless fuel payments with fraud reduction
 
 ## Context
-Gazprom Neft managed cashless fuel payments for a very large base of corporate customers (70,000+ legal entities). Paper fuel coupons and manual reconciliation created operational drag and opened space for fraud, producing direct losses and slow settlement cycles.
+A major national oil company managed cashless fuel payments for a very large base of corporate customers (70,000+ legal entities). Paper fuel coupons and manual reconciliation created operational drag and opened space for fraud, producing direct losses and slow settlement cycles.
 
 ## The Decision Challenge
 The core decision was whether to keep improving controls around a paper-based model or to move the settlement mechanism onto an instrument that supports traceability and enforceable rules. A wrong choice risked continued fraud exposure and an ever-growing reconciliation effort that would not scale with the customer base.

--- a/_projects/06. OilPC - OILPC-LOY.md
+++ b/_projects/06. OilPC - OILPC-LOY.md
@@ -4,7 +4,7 @@ client_side_industry: [oil-gas, retail]
 my_side_industry: [it-services, finance]
 delivery_model: [managed-service, platform-operator, service-outsourcing]
 engagement: [external]
-client_name_visibility: [public]
+client_name_visibility: [hidden]
 project_code: [OILPC-LOY]
 functional: [analytics, loyalty, retail-technologies]
 roles: [business-analyst, solution-architect, project-manager]
@@ -12,7 +12,7 @@ roles: [business-analyst, solution-architect, project-manager]
 # Loyalty platform for a fuel retail network
 
 ## Context
-Gazprom Neft’s fuel retail network needed loyalty to function as a business lever rather than a simple points accumulator. Without a coherent platform, personalization, measurement of campaign impact, and consistent customer experience were limited.
+A major national oil company’s fuel retail network needed loyalty to function as a business lever rather than a simple points accumulator. Without a coherent platform, personalization, measurement of campaign impact, and consistent customer experience were limited.
 
 ## The Decision Challenge
 The decision was whether to keep loyalty as a lightweight marketing tool or treat it as a customer and revenue management capability with enterprise-grade data and operational discipline. Getting it wrong would either cap growth (if too simplistic) or create a costly program that cannot be operated consistently across channels (if too complex too early).

--- a/_projects/08. Gamma - GAM-NAMOS.md
+++ b/_projects/08. Gamma - GAM-NAMOS.md
@@ -11,7 +11,7 @@ roles: [business-analyst, solution-architect, system-analyst]
 # Architecture audit and standards-aligned documentation for PSMS software
 
 ## Context
-Wincor Nixdorf had an operational petrol station management system in the field, but the architectural knowledge and documentation were not sufficiently current or standardized. This created support and evolution risk and complicated alignment with local and European expectations for documentation quality.
+A global technology supplier for banking and retail had an operational petrol station management system in the field, but the architectural knowledge and documentation were not sufficiently current or standardized. This created support and evolution risk and complicated alignment with local and European expectations for documentation quality.
 
 ## The Decision Challenge
 The decision was whether to treat documentation as a compliance artifact or as a control mechanism that reduces operational and delivery risk. In mature, already-running software, gaps in architectural understanding translate into slower incident resolution, fragile integrations, and costly change.

--- a/_projects/09. Gamm - GAM-CAR5.md
+++ b/_projects/09. Gamm - GAM-CAR5.md
@@ -11,7 +11,7 @@ roles: [solution-architect, project-manager]
 # Carsharing service launch with cloud-based fleet operations
 
 ## Context
-CAR5 planned a carsharing launch from zero, requiring an operational backbone for fleet availability, customer interaction, and integration with in-car devices and external service providers. The viability of the business depended on reliability and the ability to scale with growth in users and vehicles.
+A car-sharing service planned a carsharing launch from zero, requiring an operational backbone for fleet availability, customer interaction, and integration with in-car devices and external service providers. The viability of the business depended on reliability and the ability to scale with growth in users and vehicles.
 
 ## The Decision Challenge
 The central decision was how to design for reliability and scalability before real-world load patterns were known. A minimal build risked rework and fragility under growth; a heavy upfront design risked overinvestment and slow time-to-market.

--- a/_projects/10. Gamma - GAM-X5.md
+++ b/_projects/10. Gamma - GAM-X5.md
@@ -11,7 +11,7 @@ roles: [business-analyst, enterprise-architect, solution-architect]
 # Monitoring and predictive maintenance concept for retail climate equipment
 
 ## Context
-X5 Retail Group faced product losses and elevated electricity costs due to inconsistent temperature control in stores. Equipment failures were handled reactively, with limited ability to plan maintenance or understand systemic drivers of downtime and spoilage.
+A major national retail group faced product losses and elevated electricity costs due to inconsistent temperature control in stores. Equipment failures were handled reactively, with limited ability to plan maintenance or understand systemic drivers of downtime and spoilage.
 
 ## The Decision Challenge
 The decision was how to structure an investment in monitoring and predictive maintenance so that it produces measurable impact (including a 10% electricity cost reduction target) without creating a solution that stores cannot operate consistently. The risk of choosing poorly was high: either continued losses from downtime/spoilage or a costly initiative with unclear economics.

--- a/_projects/11. Gamma - Omni-channel communications.md
+++ b/_projects/11. Gamma - Omni-channel communications.md
@@ -11,7 +11,7 @@ roles: [business-analyst, project-manager]
 # Omnichannel client notifications under compliance and volume constraints
 
 ## Context
-VTB Pension Fund needed to communicate with clients reliably and at scale. Communication processes were fragmented: no unified recipient lists, limited segmentation, and inconsistent scenarios, which made timely and accurate notifications difficult.
+A major private pension fund needed to communicate with clients reliably and at scale. Communication processes were fragmented: no unified recipient lists, limited segmentation, and inconsistent scenarios, which made timely and accurate notifications difficult.
 
 ## The Decision Challenge
 The decision was whether to keep operating as a set of ad-hoc mailings or to establish a managed communication capability across channels. The cost of getting it wrong was both operational (missed or late messages at scale) and reputational, especially when clients depend on timely information about their accounts.

--- a/_projects/15. Rostelecom.Restream - RTK-LAKE.md
+++ b/_projects/15. Rostelecom.Restream - RTK-LAKE.md
@@ -3,7 +3,7 @@ title: "Data lake presale and solution defense for an oil & gas enterprise"
 client_side_industry: [oil-gas]
 my_side_industry: [telecom]
 engagement: [external]
-client_name_visibility: [public]
+client_name_visibility: [hidden]
 project_code: [RTK-LAKE]
 functional: [analytics]
 roles: [business-analyst]
@@ -11,7 +11,7 @@ roles: [business-analyst]
 # Data lake presale and solution defense for an oil & gas enterprise
 
 ## Context
-Gazprom Neft needed to work with large, heterogeneous datasets across fuel supply and sales and related products. Existing approaches struggled with scale and variety, limiting the organization’s ability to extract insights and identify new profit opportunities.
+A major national oil company needed to work with large, heterogeneous datasets across fuel supply and sales and related products. Existing approaches struggled with scale and variety, limiting the organization’s ability to extract insights and identify new profit opportunities.
 
 ## The Decision Challenge
 The decision challenge was to frame a “data lake” not as a technology trend but as a coherent capability with clear business cases, costs, and implementation risks. Presale success depended on translating data ambitions into a defendable architecture and a credible delivery path under competitive scrutiny.

--- a/_projects/34. EPAM - AD.md
+++ b/_projects/34. EPAM - AD.md
@@ -11,7 +11,7 @@ roles: [enterprise-architect]
 # Core retail platform roadmap under M&A-driven complexity
 
 ## Context
-Ahold Delhaize underwent multiple transformations and acquisitions, creating a complex retail and IT landscape with duplicated functions and unclear platform ownership. Omnichannel growth depended on deciding what to standardize and what to allow to remain local.
+A major European retail group underwent multiple transformations and acquisitions, creating a complex retail and IT landscape with duplicated functions and unclear platform ownership. Omnichannel growth depended on deciding what to standardize and what to allow to remain local.
 
 ## The Decision Challenge
 The decision challenge was how to define a core retail platform direction that optimizes investment without stalling delivery. Choosing “one platform for everything” can be unrealistic in post-merger environments; choosing to keep everything local preserves duplication and cost.

--- a/_projects/35. EPAM - Digital Business Transformation (BTCL-ARCO (1)).md
+++ b/_projects/35. EPAM - Digital Business Transformation (BTCL-ARCO (1)).md
@@ -3,7 +3,7 @@ title: "Target-state information architecture for marketplace transformation"
 client_side_industry: [telecom]
 my_side_industry: [consulting]
 engagement: [external]
-client_name_visibility: [public]
+client_name_visibility: [hidden]
 project_code: [BTCL-ARCO (1)]
 functional: [architecture]
 roles: [enterprise-architect]

--- a/_projects/36. EPAM - AC.md
+++ b/_projects/36. EPAM - AC.md
@@ -11,7 +11,7 @@ roles: [business-analyst, solution-architect, product-manager]
 # Authorization cockpit planning under MVP time pressure
 
 ## Context
-Danfoss needed a new authorization management application for users and partners, with an MVP expected within the year. The initiative required clarity on scope, priorities, and how the solution fits the broader identity and access landscape.
+A European industrial equipment manufacturer needed a new authorization management application for users and partners, with an MVP expected within the year. The initiative required clarity on scope, priorities, and how the solution fits the broader identity and access landscape.
 
 ## The Decision Challenge
 The decision challenge was to define an MVP that is meaningful and safe: enough capability to support partner authorization needs, but not so much that it becomes a multi-year program. Vendor choice also depended on an explicit view of required capabilities and the organization’s constraints.

--- a/_projects/37. EPAM - Lead-to-cash.md
+++ b/_projects/37. EPAM - Lead-to-cash.md
@@ -11,7 +11,7 @@ roles: [business-analyst, enterprise-architect, product-manager]
 # Subscription management blueprint for lead-to-cash transformation
 
 ## Context
-Danfoss moved toward a service-based business model, which required subscription management as a connective layer between customer engagement and enterprise operations. The organization needed a coherent blueprint before committing to implementation.
+A European industrial equipment manufacturer moved toward a service-based business model, which required subscription management as a connective layer between customer engagement and enterprise operations. The organization needed a coherent blueprint before committing to implementation.
 
 ## The Decision Challenge
 The decision challenge was how to design a subscription capability that supports the business shift without creating a brittle integration layer. A weak design would lock the organization into expensive workarounds between commercial processes and operational fulfillment.

--- a/_projects/38. EPAM - Product Domain Transformation (BTCL-ARCO (2)).md
+++ b/_projects/38. EPAM - Product Domain Transformation (BTCL-ARCO (2)).md
@@ -3,7 +3,7 @@ title: "Product domain restructuring for a digital marketplace direction"
 client_side_industry: [telecom]
 my_side_industry: [consulting]
 engagement: [external]
-client_name_visibility: [public]
+client_name_visibility: [hidden]
 project_code: [BTC-ARCO (2)]
 functional: [architecture]
 roles: [product-domain-architect]

--- a/_projects/39. EPAM - Architecture Analysis for Fuel Retail.md
+++ b/_projects/39. EPAM - Architecture Analysis for Fuel Retail.md
@@ -11,7 +11,7 @@ roles: [enterprise-architect, solution-architect]
 # Stabilizing fuel retail operations affected by loyalty outages
 
 ## Context
-ADNOC experienced critical disruptions at petrol stations where loyalty program outages could cascade into full service shutdowns. The issue sat at the intersection of operational processes, integrations, and station hardware/software dependencies.
+A major oil & gas company in the Middle East experienced critical disruptions at petrol stations where loyalty program outages could cascade into full service shutdowns. The issue sat at the intersection of operational processes, integrations, and station hardware/software dependencies.
 
 ## The Decision Challenge
 The decision challenge was how to restore stability quickly while avoiding a “patch and hope” cycle that would repeat the same incidents. The wrong approach would either prolong revenue loss (if too slow) or create temporary fixes that fail under the next load or change.


### PR DESCRIPTION
Aligns site `_projects/*` with the canonical knowledge base (source of truth for `client_name_visibility`). Refs vkgeorgia/strategy#363.

- Visibility flags reconciled to canonical: cases 05, 06, 15, 35, 38.
- Case bodies use the canonical neutral descriptor (from the alternatives file, verbatim) instead of a named organisation: cases 05, 06, 08, 09, 10, 11, 15, 34, 36, 37, 39.
- Build clean; rendered `/cases/` verified against the canonical alternatives.
- PR title, description, branch, and commit messages carry no client names.

Do not merge — gating is yours.