### PR TITLE
Repository hygiene: tidy build excludes, document SEO landing-page dirs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -66,16 +66,16 @@ exclude:
   - digital-avatar/.env
   - digital-avatar/google_credentials.json
   - digital-avatar/README.md
-  # Локальные планы/доки в корне (см. .gitignore) — не обрабатывать как страницы Jekyll
+  # Local-only docs / private brief in root (see .gitignore) — never build as pages
   - CLAUDE.md
-  - new-proposed-format
   - vkgeorgia.icloud.com
-  - 00_SUMMARY_AND_NEXT_STEPS.md
-  - BOT_IMPLEMENTATION_PLAN.md
-  - FINAL_IMPLEMENTATION_PLAN.md
-  - PHASE_0_BUILD_FIX_CLASSIFICATION.md
-  - STYLE_GUIDE.md
-  # Архив устаревшего контента — не собирается Jekyll
+  - STRATEGIC_BRIEF.md
+  # Repo-internal notes for the SEO landing-page directories — not built
+  - domains/README.md
+  - industries/README.md
+  - projects/README.md
+  - roles/README.md
+  # Archived stale content (see .gitignore) — not built by Jekyll
   - "0. archive"
 
 # Collections

--- a/domains/README.md
+++ b/domains/README.md
@@ -1,0 +1,7 @@
+# `domains/`
+
+Functional-domain landing pages (one per domain, e.g. omni-channel, data, integration). Each renders at `/domains/<key>/` and is indexed in `sitemap.xml`.
+
+These are **deep-linked SEO landing pages — intentionally not in the main navigation** (Home / Business Challenges / Services / Cases / Articles). They are reachable directly and via search engines.
+
+Repo-internal note only; excluded from the Jekyll build.

--- a/industries/README.md
+++ b/industries/README.md
@@ -1,0 +1,7 @@
+# `industries/`
+
+Industry landing pages (one per industry, e.g. manufacturing, telecom, finance). Each renders at `/industries/<key>/` and is indexed in `sitemap.xml`.
+
+These are **deep-linked SEO landing pages — intentionally not in the main navigation** (Home / Business Challenges / Services / Cases / Articles). They are reachable directly and via search engines.
+
+Repo-internal note only; excluded from the Jekyll build.

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,9 @@
+# `projects/`
+
+Industry-grouped project listing pages (e.g. oil-gas, telecom, consulting). Each renders at `/projects/<key>/` and is indexed in `sitemap.xml`.
+
+**Distinct from `_projects/`** — that is the Jekyll collection that builds the `/cases/` page. This `projects/` directory holds standalone category listing pages.
+
+These are **deep-linked SEO landing pages — intentionally not in the main navigation** (Home / Business Challenges / Services / Cases / Articles). They are reachable directly and via search engines.
+
+Repo-internal note only; excluded from the Jekyll build.

--- a/roles/README.md
+++ b/roles/README.md
@@ -1,0 +1,7 @@
+# `roles/`
+
+Role landing pages (one per role, e.g. project-manager, enterprise-architect). Each renders at `/roles/<key>/` and is indexed in `sitemap.xml`.
+
+These are **deep-linked SEO landing pages — intentionally not in the main navigation** (Home / Business Challenges / Services / Cases / Articles). They are reachable directly and via search engines.
+
+Repo-internal note only; excluded from the Jekyll build.


### PR DESCRIPTION
Repository hygiene — source-tree organisation only; does not change what the deployed site publishes. Refs vkgeorgia/strategy#387.

## Tracked changes (this diff)
- **`_config.yml`** — removed stale `exclude:` entries for planning docs now archived locally; added the private root brief and the four new repo-internal READMEs to `exclude` so they never build into pages.
- **`domains/`, `industries/`, `projects/`, `roles/` READMEs** — these four directories render to `/<dir>/<key>/` and are in `sitemap.xml` (deep-linked SEO landing pages, not in main nav). Per the audit they are **reachable → kept**, with a short README documenting purpose. READMEs are excluded from the build.

## Local working-tree hygiene (gitignored — intentionally not in this diff)
- Moved stale planning docs, a duplicated style reference, the superseded proposed-format folder, and an old photo backup under `0. archive/` (kept, not deleted, per the archival convention).
- Removed `.DS_Store` files from the working tree.
- The private root brief stays at root (per decision) but no longer builds into a page.

## Verification (Phase 4)
- `bundle exec jekyll build` clean.
- `_site` diffed against a pre-change baseline: **deployed output unchanged**. The only deltas are removals of local-only, gitignored artifacts that were never part of the committed/deployed site (a private brief page, an old photo backup, an internal planning doc) — plus the build-timestamp in `feed.xml`. The four kept directories remain in `sitemap.xml` (16 / 11 / 9 / 6 URLs).
- New `0. archive/` subfolders confirmed gitignored.
