### PR TITLE
Add a full Transitrix / architecture-as-code section to the homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -84,7 +84,15 @@ When the decisions keep coming, a fractional or embedded arrangement makes more 
 
 And when a board, investor, or PE firm needs an independent read on a portfolio company or a single technology decision, I take on expert due diligence or a second opinion — a matter of days to weeks.
 
-*Currently researching architecture-as-code; methodology and tooling open-sourced at [transitrix.com](https://transitrix.com).*
+---
+
+## Architecture-as-code — an open methodology I build
+
+My practice treats enterprise architecture as a decision discipline, not documentation. **Transitrix** is where I take that conviction further, in the open: an architecture-as-code methodology that describes an enterprise as text — its goals, capabilities, processes, and roles. Because the model is text, it can be versioned in Git, reviewed like code, and read by both people and machines. It builds on open standards (ArchiMate, BPMN) and is MIT-licensed.
+
+Alongside the methodology I build **Transitrix Studio**, an editor extension and CLI that authors and previews these models directly in VS Code and other IDEs. It is a research initiative, not a product I am selling here — but it reflects how I think architecture should work: legible, current, and owned by the organisation rather than locked in a tool.
+
+More at [transitrix.com](https://transitrix.com).
 
 ---
 


### PR DESCRIPTION
Replaces the one-line Transitrix disclosure with a short dedicated homepage section, now that the initiative is in active development. Refs vkgeorgia/strategy#41.

## What changed
- New `## Architecture-as-code — an open methodology I build` section on the homepage (between "How we can work together" and "Let's talk"), replacing the prior one-liner.
- Introduces the open methodology and **Transitrix Studio** (editor extension + CLI), links `transitrix.com`.

## Positioning (per strategy-hub canon)
- **First-person, advisor voice** — Transitrix framed as one of Valerii's current research initiatives, explicitly "not a product I am selling here." Per `BRAND_COMMS_GUIDE §1/§3`: personal site stays centred on the advisory practice; mentions Transitrix and links out; does not adopt the institutional Transitrix voice.
- Bridges the site's existing "EA as a decision discipline, not documentation" framing into the architecture-as-code initiative.
- Facts (text-native model, Git/PR review, ArchiMate/BPMN, MIT, Studio across IDEs) aligned with `transitrix.com` and the strategy-hub one-pager.
- Build clean; section renders with the `transitrix.com` link.

## For strategy-layer review (per #41)
Copy/positioning to be confirmed against `STYLE_GUIDE` / `BRAND_COMMS_GUIDE` before merge. Open to tightening length, heading, or emphasis. Leaving the issue open pending your review.

Do not merge — gating is yours.