### PR TITLE
feat: Cloudflare Web Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,6 +48,10 @@ include:
 # Для локальной подмены без коммита: _config.local.yml + --config _config.yml,_config.local.yml
 backend_url: "https://ai-avatar-103512681014.us-central1.run.app"
 
+# Cloudflare Web Analytics token (JS beacon, public — visible in HTML source on live site, not a secret).
+# Referenced from _layouts/default.html. See strategy issue vkgeorgia/strategy#391.
+cloudflare_analytics_token: "c469758a75af452284beff013fcc9741"
+
 # Exclude from processing
 exclude:
   - README.md

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,6 +49,12 @@
     <link rel="stylesheet" href="{{ '/digital-avatar/frontend/widget.css' | relative_url }}">
     <script src="{{ '/digital-avatar/frontend/widget.js' | relative_url }}"></script>
 
+    {% if site.cloudflare_analytics_token %}
+    <!-- Cloudflare Web Analytics -->
+    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "{{ site.cloudflare_analytics_token }}"}'></script>
+    <!-- End Cloudflare Web Analytics -->
+    {% endif %}
+
 </body>
 
 </html>


### PR DESCRIPTION
Adds Cloudflare Web Analytics (JS beacon) to the site, matching the transitrix.com setup. Refs vkgeorgia/strategy#391.

## Changes (exactly per the issue's spec)
- `_config.yml` — `cloudflare_analytics_token` field (public token; appears in live HTML source, not a secret).
- `_layouts/default.html` — beacon added next to the chat-widget scripts, so it fires on **all pages** via the universal layout. Wrapped in `{% if site.cloudflare_analytics_token %}` so removing the token cleanly disables analytics with no code change.

## Verification (local build)
- `bundle exec jekyll build` clean.
- Beacon renders with the real token; present on home, `/cases/`, and `/services/`; no unrendered Liquid.

## Live verification (after you merge + deploy)
1. Wait ~1–2 min for GitHub Pages rebuild.
2. Open `https://vkgeorgia.github.io/` → DevTools → Network → filter `cloudflareinsights.com` → reload → confirm `beacon.min.js` returns 200.
3. Wait ~5 min → Cloudflare dashboard → Web Analytics → `vkgeorgia.github.io` → events appear.

No cookies / PII / consent banner (cookieless privacy-friendly analytics).

Do not merge — gating is yours.