### PR TITLE
Anchor case studies + cases index restructure

### DIFF
--- a/_case_studies/cashless-fuel-settlement.md
+++ b/_case_studies/cashless-fuel-settlement.md
@@ -1,0 +1,50 @@
+---
+layout: case
+title: "Replacing paper fuel vouchers with a cashless platform for 70,000+ corporate clients"
+seo_title: "Cashless Corporate Payment Platform — Enterprise Architecture Case Study"
+description: "How an enterprise architect replaced paper fuel-voucher settlements with a cashless corporate card platform for 70,000+ clients, cutting reconciliation sixfold and fraud losses tenfold."
+client_display: "A major national oil company — fuel retail with 70,000+ B2B counterparties"
+industry: "Energy & fuel retail"
+role: "Enterprise Architect"
+period: "Solutions Architect / Enterprise Architect"
+order: 2
+teaser: "Reconciliation time cut 6× and fraud-related losses cut 10× — by replacing paper-coupon settlement with a cashless platform that builds control and traceability into the payment lifecycle."
+lang: en
+---
+
+**Replaced paper fuel vouchers with a cashless corporate card platform for 70,000+ clients — reconciliation cut from weeks to days (6× faster) and fraud-related losses cut roughly 10× — by building control and traceability into the payment lifecycle rather than bolting it on afterwards.**
+
+## Context
+
+A major national oil company managed cashless fuel payments for a very large base of corporate customers — over 70,000 legal entities. Paper fuel coupons and manual reconciliation created constant operational drag and opened space for fraud, producing direct losses and slow settlement cycles. At that scale, edge cases could no longer be handled by hand.
+
+## The decision
+
+The obvious framing was "replace paper with plastic." I reframed it as a control-system design: the real question was whether compliance should keep depending on retrospective oversight, or be designed into every issuance, transaction, and settlement so that an invalid action is rejected at the point of authorisation rather than caught weeks later.
+
+## Constraints and trade-offs
+
+- **Scale.** At 70,000+ entities and hundreds of thousands of weekly transactions, manual exception-handling was not an option — the design had to be scale-resistant.
+- **Integration.** The platform had to fit existing financial systems and stay compatible with the gas-station network and corporate-client adoption.
+- **Trade-off I accepted.** More upfront architectural work and stakeholder alignment, in exchange for a repeatable, fraud-resistant process — rather than digitising the existing workflow and carrying its structural weaknesses forward.
+
+## Approach
+
+I designed a three-layer platform and brought the client's security team into the architecture from the start, so audit trails and limits were designed in, not retrofitted.
+
+1. **Payment-instrument lifecycle** — card issuance, activation, limits, blocking, and status managed as a state machine.
+2. **Real-time rules engine** — balance, limit, approved-merchant, and compromise checks at the point of sale, with fraud thresholds the client's compliance team could adjust without code changes.
+3. **Automated settlement and reconciliation** — structured transaction data matched against client invoices, with discrepancies flagged algorithmically.
+
+Through migration, paper vouchers and cards ran in parallel for the 70,000+ clients — risk reduction, not waste.
+
+## Outcome
+
+- **Reconciliation:** 4–6 weeks of manual verification to 3–4 days automated — **6× faster**.
+- **Fraud losses:** reduced roughly **10×**, via point-of-authorisation controls rather than after-the-fact detection.
+- **Scale:** the platform carried 70,000+ active corporate clients and hundreds of thousands of weekly transactions, with faster per-account onboarding.
+- The client formally recognised the business impact.
+
+## What it shows
+
+Controls belong inside the process, not on top of it: a rules engine that rejects an invalid transaction in real time prevents the loss; a review that catches it days later cannot undo it. And reconciliation turned out to be a process-design problem, not a reporting one — engineering structured data and algorithmic matching into settlement is what took it from weeks to days and made it defensible.

--- a/_case_studies/product-portfolio-harmonisation.md
+++ b/_case_studies/product-portfolio-harmonisation.md
@@ -1,0 +1,49 @@
+---
+layout: case
+title: "Consolidating a 4,600-product portfolio across 19 legal entities"
+seo_title: "Product Portfolio Harmonisation — Enterprise Architecture Case Study"
+description: "How an enterprise architect reduced a national airport's product portfolio from 4,600 to 1,200 across 19 legal entities, preserving profitability and cutting time-to-market threefold."
+client_display: "Domodedovo Airport — a national top-2 aviation hub"
+industry: "Aviation & transport"
+role: "Enterprise Architect"
+period: "2019–2021 (16 months)"
+order: 1
+teaser: "Product portfolio reduced from 4,600 to 1,200 and time-to-market cut threefold — by reframing a clean-up as a product-strategy decision and standardising one methodology across 19 legal entities."
+lang: en
+---
+
+**Reduced the product portfolio from 4,600 to 1,200 across 19 legal entities — profitability preserved and concentrated, time-to-market cut threefold, and one product-management methodology adopted group-wide.**
+
+## Context
+
+Domodedovo Airport's product portfolio had grown organically for years without systematic governance. The result was 4,600 products with unclear classification, heavy duplication and functional overlap, and many outdated or unprofitable positions. Each of the group's 19 legally independent entities ran product management its own way. Time-to-market was slow, per-product profit contribution was unclear, and there was no strategic roadmap.
+
+## The decision
+
+The question looked operational — *which products do we cut?* — but it was a business-model decision. My first contribution was to reframe it: not "how many products should we have?" but "what is our product strategy, and what classification lets us manage it?" Everything else — the cut from 4,600 to 1,200, the process redesign, the cross-entity rollout — followed from that.
+
+## Constraints and trade-offs
+
+- **Nineteen independent entities.** Each had its own product practice and stakeholders. Nothing could be imposed by fiat; the methodology had to be adopted, not announced.
+- **Revenue continuity.** The transition could not disturb revenue across the 16 months of execution.
+- **Stakeholder spread.** Portfolio decisions touched commercial, finance, operations, IT, and service delivery — each with a different local view.
+- **Trade-off I accepted.** Standardising across 19 entities was slower than a single-entity programme would have been. The cross-entity coherence was worth the slower path.
+
+## Approach
+
+I structured the work in four layers and ran it in four phases over 16 months.
+
+1. **Portfolio analysis and classification.** All 4,600 products analysed by type, segment, revenue, and profitability, with duplication and overlap mapped and benchmarked against comparable airports.
+2. **Product strategy.** Strategic positioning first — which segments to serve, which categories aligned with that positioning, what to invest in, what to retire.
+3. **Process reengineering.** The ideation-to-launch process redesigned around the bottlenecks, with a governance and decision framework and the supporting IT changes — the redesign that delivered the 3× time-to-market compression.
+4. **Change management.** Methodology documentation, training for product managers across all 19 entities, and the governance structure that made adoption stick.
+
+## Outcome
+
+- **73% portfolio reduction** — 4,600 to 1,200 — with profitability preserved and concentrated in the products that earned it.
+- **Time-to-market cut 3×** through the redesigned development process.
+- **One product-management methodology** adopted across all 19 legal entities, with the governance to keep the portfolio optimised rather than letting it re-accumulate.
+
+## What it shows
+
+Portfolio strategy has to precede portfolio decisions: setting the strategy first made every elimination defensible and aligned to the business, rather than a cost-cut that invites argument. And the durable win was the process, not the number — reducing to 1,200 was the tactical result; standardising the methodology that keeps it there was the strategic one.

--- a/_case_studies/subscription-business-model.md
+++ b/_case_studies/subscription-business-model.md
@@ -1,0 +1,51 @@
+---
+layout: case
+title: "Architecting the shift from equipment sales to a subscription business"
+seo_title: "Subscription Business-Model Transformation — Enterprise Architecture Case Study"
+description: "How an enterprise architect designed the subscription-management blueprint a European industrial equipment manufacturer needed to move from product sales to a service business — bridging CRM, subscription, and ERP."
+client_display: "A European industrial equipment manufacturer"
+industry: "Industrial manufacturing"
+role: "Enterprise Architect (solo engagement)"
+period: "2024 (4 months)"
+order: 3
+teaser: "Designed the subscription-management blueprint for a move from equipment sales to a service business — bridging CRM, subscription, and ERP into one order-to-quote flow, with vendor selection anchored on architectural fit."
+lang: en
+---
+
+**Designed the subscription-management blueprint a European industrial equipment manufacturer needed to evolve from a product-sales business into a service business — bridging CRM, the new subscription layer, and ERP into a single order-to-quote flow, with vendor selection anchored on architectural fit rather than feature lists.**
+
+## Context
+
+A European industrial equipment manufacturer faced a strategic imperative to move beyond selling equipment. The market was shifting toward service-based offerings, and capturing recurring revenue through subscriptions required more than a feature — it required a new operating model. Underneath the strategy sat an architectural problem: any subscription solution had to bridge the customer-facing CRM, where orders originate, and the back-end ERP, where billing, revenue recognition, and fulfilment live — through a new subscription layer handling flexible pricing, packaging, and contract lifecycle. The two systems had no shared order-to-quote flow for subscriptions.
+
+## The decision
+
+Leadership wanted the robust, integrated, buy-not-build path. That made architecture-first sequencing essential: choosing a vendor well was impossible until the target capabilities and integration model were clear. I held the line on capability before system, against real pressure to evaluate feature-rich vendor solutions first.
+
+## Constraints and trade-offs
+
+- **Solo, four months.** No team to delegate to — scope had to be deliverable by one architect at sustained quality.
+- **Cross-functional stakeholders.** Sales, finance, operations, and IT each held a local view; the blueprint needed a global one.
+- **Vendor-marketing pressure.** Vendors were already pitching. The pull to shortlist before the architecture was settled was strong.
+- **Trade-off I accepted.** A comprehensive blueprint took longer than a quick fix, but the clarity it gave made every later decision — vendor, integration, sequencing — cleaner.
+
+## Approach
+
+I worked from capability before system, in five layers.
+
+1. **Landscape.** Surveyed the current architecture, business rules, CRM/ERP integration touchpoints, and capability gaps.
+2. **Stakeholder alignment.** Interviews across sales, operations, IT, and finance; conflicting priorities surfaced and resolved rather than averaged.
+3. **Capability design.** Current-state (equipment sales) and future-state (subscription) capability maps, naming the new capabilities required — contract lifecycle, recurring billing, revenue recognition, dynamic pricing.
+4. **Solution blueprint.** Data models for subscription contracts, pricing, and billing; integration patterns for CRM ↔ subscription ↔ ERP; the order-to-quote workflow.
+5. **Implementation strategy.** A prioritised roadmap and a vendor-selection framework anchored on architectural fit, not feature checklists. I stayed into early build to validate the blueprint under real pressure.
+
+## Outcome
+
+- A current- and future-state capability map giving leadership a clear view of what the subscription model required.
+- A solution blueprint and CRM ↔ subscription ↔ ERP integration design that kept the new system from becoming an isolated silo.
+- A vendor-selection framework built on architectural-fit criteria — a foundation for choosing the platform on fit, not marketing.
+- The blueprint held up under early build: the architecture survived contact with implementation.
+
+## What it shows
+
+When a company changes its business model, it is not buying a new system — it is adopting a new operating model, and the architecture has to start from business capability rather than vendor features. The integration strategy is what decides whether subscription transformation succeeds, which is exactly why it has to precede vendor selection, not follow it.

--- a/_config.yml
+++ b/_config.yml
@@ -74,6 +74,8 @@ exclude:
   - CLAUDE.md
   - vkgeorgia.icloud.com
   - STRATEGIC_BRIEF.md
+  # Repo-internal architecture decision records — not built into the site
+  - docs/
   # Repo-internal notes for the SEO landing-page directories — not built
   - domains/README.md
   - industries/README.md
@@ -86,3 +88,8 @@ exclude:
 collections:
   projects:
     output: false
+  # Anchor case studies — long-form, individually addressable at /cases/<slug>/.
+  # Distinct from the `projects` collection (brief filterable cards on /cases/).
+  case_studies:
+    output: true
+    permalink: /cases/:name/

--- a/_includes/highlights.html
+++ b/_includes/highlights.html
@@ -1,9 +1,8 @@
 {%- comment -%}
-  Shared block of three anchor case outcomes.
-  Used on the home page ("Selected outcomes") and on cases.md ("Highlights").
-  Kept in one place so numbers and phrasing stay consistent across the site.
-  The calling page provides its own heading and surrounding context.
+  Shared block of three anchor case outcomes — the home page "Selected outcomes".
+  Each outcome has a matching long-form case study under /cases/ (the
+  case_studies collection); keep the phrasing here aligned with those pages.
 {%- endcomment -%}
 - **National top-2 aviation hub.** Product portfolio reduced from 4,600 to 1,200 items and time-to-market cut threefold — by rebuilding classification, lifecycle rules, and governance across 19 legal entities.
 - **Fuel retail with over 70,000 B2B counterparties.** Reconciliation time cut 6× and fraud-related losses cut 10× — by replacing paper-coupon settlements with a cashless platform and architecting the surrounding governance.
-- **Global IT services firm, approximately 68,000 employees.** 80% of HR inquiries across 12 processes resolved without human intervention, 99% answer accuracy, response times from days to minutes — by architecting the HR assistant and its knowledge and integration layer.
+- **European industrial equipment manufacturer.** Architected the move from equipment sales to a subscription business — bridging CRM, subscription, and ERP into a single order-to-quote flow, with vendor selection anchored on architectural fit rather than feature lists.

--- a/_layouts/case.html
+++ b/_layouts/case.html
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+
+<article class="post case-study">
+    <p class="case-back"><a href="{{ '/cases/' | relative_url }}">← All cases</a></p>
+
+    <header class="post-header">
+        <h1 class="post-title">{{ page.title | escape }}</h1>
+        {% if page.client_display %}<p class="case-client">{{ page.client_display }}</p>{% endif %}
+        <p class="case-meta">
+            {% if page.industry %}{{ page.industry }}{% endif %}
+            {% if page.role %}<span class="case-meta-sep">·</span> {{ page.role }}{% endif %}
+            {% if page.period %}<span class="case-meta-sep">·</span> {{ page.period }}{% endif %}
+        </p>
+    </header>
+
+    <div class="post-content">
+        {{ content }}
+    </div>
+
+    <hr />
+
+    <p><strong><a href="https://calendar.app.google/YwmXZytfSQ2qWX4Z7">→ Book a 30-min intro call</a></strong> to talk through a similar decision in your organisation.</p>
+
+    <p class="case-back"><a href="{{ '/cases/' | relative_url }}">← Back to all cases</a></p>
+</article>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -242,3 +242,60 @@ hr + h3 {
         text-align: left;
     }
 }
+
+/* Featured case-study teaser cards (cases index) */
+.featured-cases {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+    margin: 1.5rem 0;
+}
+
+.featured-case {
+    padding: 1.25rem 1.5rem;
+    border: 1px solid #e0e0e0;
+    border-left: 3px solid #2a7ae2;
+    border-radius: 8px;
+    background: #fafafa;
+}
+
+.featured-case h3 {
+    margin: 0 0 0.25rem 0;
+}
+
+.featured-case-client {
+    margin: 0 0 0.6rem 0;
+    font-size: 0.9rem;
+    color: #666;
+}
+
+.featured-case-teaser {
+    margin: 0 0 0.6rem 0;
+}
+
+.featured-case-more {
+    margin: 0;
+    font-weight: 500;
+}
+
+/* Long-form case-study page */
+.case-study .case-back {
+    font-size: 0.9rem;
+    margin-bottom: 0.5rem;
+}
+
+.case-study .case-client {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin: 0.25rem 0 0.15rem 0;
+}
+
+.case-study .case-meta {
+    font-size: 0.9rem;
+    color: #666;
+    margin: 0;
+}
+
+.case-study .case-meta-sep {
+    color: #bbb;
+}

--- a/cases.md
+++ b/cases.md
@@ -23,15 +23,27 @@ Use the filters below to narrow by industry, role, or functional domain.
 
 ---
 
-## Highlights
+## Featured case studies
 
-A few engagements that illustrate the type of outcomes this work tends to produce:
+A few engagements in depth — the decision, the trade-offs, and the outcome.
 
-{% include highlights.html %}
-
-The full list, with filters by industry, role, and functional domain, is below.
+<div class="featured-cases">
+{% assign featured = site.case_studies | sort: "order" %}
+{% for case in featured %}
+  <div class="featured-case">
+    <h3><a href="{{ case.url | relative_url }}">{{ case.title }}</a></h3>
+    {% if case.client_display %}<p class="featured-case-client">{{ case.client_display }}</p>{% endif %}
+    <p class="featured-case-teaser">{{ case.teaser }}</p>
+    <p class="featured-case-more"><a href="{{ case.url | relative_url }}">Read the case →</a></p>
+  </div>
+{% endfor %}
+</div>
 
 ---
+
+## Other engagements
+
+The full list, with filters by industry, role, and functional domain, is below.
 
 <style>
   /* Filter Container */

--- a/docs/decisions/2026-06-27-anchor-case-studies.md
+++ b/docs/decisions/2026-06-27-anchor-case-studies.md
@@ -1,0 +1,47 @@
+# Anchor case studies — long-form case pages
+
+- **Status:** Accepted
+- **Date:** 2026-06-27
+- **Task:** [strategy#216](https://github.com/vkgeorgia/strategy/issues/216) (part of epic [#104](https://github.com/vkgeorgia/strategy/issues/104) — personal-brand inbound engine)
+
+## Purpose
+
+Publish 2–3 long-form "anchor" case studies with operational and product-domain depth, individually addressable, so the site carries proof that converts inbound — and so the home "Selected outcomes" and the deep dives tell one coherent story.
+
+## Decision
+
+### Format — a dedicated `case_studies` collection
+
+A new Jekyll collection `case_studies` (`output: true`, `permalink: /cases/:name/`) renders each anchor case as its own page at `/cases/<slug>/`, via `_layouts/case.html`.
+
+Why a new collection rather than reusing `projects`: the existing `projects` collection is `output: false` (brief filterable cards only, no individual URLs). Flipping it to `output: true` would generate 44 thin URLs with no long-form layout. A separate collection gives the anchor cases real URLs without disturbing the existing cards.
+
+### Information architecture of `/cases/`
+
+`/cases/` stays the index:
+
+1. **Featured case studies** — teaser cards generated from `site.case_studies` (title, client descriptor, one-line outcome, "Read the case →" link).
+2. **Other engagements** — the existing filterable `projects` cards (unchanged).
+
+The home page keeps `_includes/highlights.html` ("Selected outcomes") as three one-line outcomes; each one maps to a featured case study, so the elevator pitch and the deep dives stay aligned.
+
+### Initial set (3)
+
+1. Product portfolio harmonisation (aviation hub) — product-domain anchor (§2.7).
+2. Cashless fuel settlement (energy / fuel retail) — operational depth.
+3. Subscription business-model transformation (industrial manufacturing) — business-model / product depth.
+
+Home "Selected outcomes" updated to match: the former HR-assistant outcome was replaced by the subscription/manufacturing one, for a single narrative across home → `/cases/`. The AI/product anchor is carried elsewhere (the architecture-as-code section and the AaC narrative), so nothing is lost.
+
+## Confidentiality
+
+- Client names follow `endeavours/client_alternatives.yaml` and `client_name_visibility`: the aviation hub is named (public, §2.6 DME exception); the other two render as their canonical alternatives ("a major national oil company", "a European industrial equipment manufacturer") — real names never appear.
+- No internal project codes on any public surface (§5.6).
+- Russia-deprioritised framing (§2.6): no country markers beyond the approved alternatives.
+- Copy written to the §3.2 voice tests (senior-partner / proof / fit).
+
+## Consequences
+
+- Anchor cases are now first-class, shareable URLs; adding another is one file in `_case_studies/`.
+- `docs/` is excluded from the Jekyll build so these ADRs are not published as site pages.
+- Source of truth for the case content is the `endeavours/` STAR records; if those numbers change, the case pages and `highlights.html` must be updated together.


### PR DESCRIPTION
Publishes three long-form anchor case studies and restructures `/cases/` as an index. Part of epic #104. Refs vkgeorgia/strategy#216.

## Format (per the agreed design)
- New Jekyll collection `case_studies` (`output: true`, `/cases/<slug>/`) + `_layouts/case.html`. The existing `projects` collection is `output: false` (cards only, no URLs), so a dedicated collection gives the anchor cases real, shareable URLs without generating 44 thin pages.
- `/cases/` index: **Featured case studies** (teaser cards generated from the collection, each with a "Read the case →" link) followed by **Other engagements** (the existing filterable project cards, unchanged).

## The three anchor cases
1. **Product portfolio harmonisation** (aviation hub) — product-domain anchor (§2.7): 4,600 → 1,200 products across 19 legal entities, TTM cut 3×.
2. **Cashless fuel settlement** (energy / fuel retail) — reconciliation 6× faster, fraud losses ~10× lower, 70,000+ clients.
3. **Subscription business-model transformation** (industrial manufacturing) — CRM ↔ subscription ↔ ERP, vendor selection on architectural fit.

## Home ↔ /cases/ narrative coherence
Home "Selected outcomes" updated: the HR-assistant outcome replaced by the subscription/manufacturing one, so the elevator pitch (home) and the deep dives (`/cases/`) tell one story. The AI/product anchor is carried by the architecture-as-code section + AaC narrative, so nothing is lost.

## Confidentiality (verified in the build)
- Names follow `client_alternatives.yaml` / `client_name_visibility`: the aviation hub is named (public, §2.6 exception); the other two render as "a major national oil company" and "a European industrial equipment manufacturer". Build scan: **zero** real private names and **zero** internal codes (§5.6) on the rendered case pages.
- Copy written to the §3.2 voice tests (senior-partner / proof / fit).

## Other
- CSS for case pages + teaser cards. ADR in `docs/decisions/` (and `docs/` excluded from the build).
- Note: this branch also adds `- docs/` to `_config.yml` exclude (same one-liner as PR #13); if #13 merges first, expect a trivial overlap there.
- Source of truth is the `endeavours/` STAR records; case pages + `highlights.html` should be updated together if those numbers change.

Do not merge — gating is yours.