### PR TITLE
Add featured case studies + restructure /cases/ index

### DIFF
--- a/_case_studies/aviation-portfolio-reorganization.md
+++ b/_case_studies/aviation-portfolio-reorganization.md
@@ -1,0 +1,45 @@
+---
+layout: case
+title: "Product portfolio reorganization at national scale"
+client_alt: "National top-2 aviation hub"
+endeavour_id: "22.27"
+engagement_type: "BUILD"
+order: 1
+period: "Nov 2019 – Feb 2021 (16 months)"
+role: "Enterprise Architect / Chief Architect, Strategic Group"
+teaser: "Consolidated a 4,600-item product portfolio to 1,200 across 19 legal entities — time-to-market cut 3×, profitability preserved."
+seo_title: "Product portfolio reorganization at a national aviation hub"
+description: "How an enterprise-architecture-led portfolio reorganization cut a 4,600-item product portfolio to 1,200 across 19 legal entities — preserving profitability and cutting time-to-market threefold."
+keywords: "Product Portfolio Optimization, Enterprise Architecture, Process Reengineering, Portfolio Rationalization, Time-to-Market, Aviation"
+lang: en
+---
+
+## Context
+
+A national top-2 aviation hub operates as a holding of 19 legally independent entities, each with its own product strategy and its own way of managing it. Over years, the group's product portfolio had grown organically — to roughly 4,600 products — without systematic governance.
+
+The result was accumulated drag rather than a single failure: unclear classification, significant duplication and functional overlap, unprofitable positions kept alive by inertia, and inconsistent product management across the 19 entities. Time-to-market for new products was slow, per-product profit contribution was opaque, and there was no strategic roadmap tying the portfolio to where the business was going. The opportunity was symmetric — a disciplined reorganization could lift profitability, accelerate launches, and free up capital allocation across the group.
+
+## Approach
+
+I framed the portfolio as a **business-model decision, not an operational detail** — moving the question from "how many products should we have?" to "what is our product strategy, and which products serve it?" That reframing made the eventual cuts defensible rather than arbitrary.
+
+The programme ran in four layers over 16 months:
+
+1. **Portfolio analysis and classification.** All ~4,600 products analysed by type, customer segment, revenue, and profitability. Duplication and overlap mapped explicitly; performance benchmarked against comparable operators.
+2. **Product strategy and prioritization.** Strategic positioning by customer segment, a portfolio strategy defining which categories to back, and a roadmap for what to develop next.
+3. **Process reengineering.** The ideation-to-launch process reassessed end to end, bottlenecks removed, and a governance and decision framework put in place — with supporting IT changes — targeting a 3× compression of the launch cycle.
+4. **Change management and capability building.** Methodology, training materials, and governance rolled out across all 19 entities, because standardization could not be imposed by fiat on legally independent units — it had to be adopted.
+
+The accepted trade-off: standardizing across 19 independent entities meant a slower per-entity rollout than a single-entity programme would have allowed. Cross-entity coherence was worth the slower path, and revenue continuity was a hard constraint throughout the transition.
+
+## Outcome
+
+- **73% portfolio reduction** — from ~4,600 to ~1,200 products — with profitability preserved and concentrated on the positions that earned it.
+- **Time-to-market cut 3×** for new products, through the reengineered launch process and governance.
+- **Profit-per-product up significantly**, as the metric itself shifted organizational behaviour from counting products to managing their contribution.
+- **A standardized product-management methodology adopted across all 19 legal entities**, so the gains persisted as a discipline rather than a one-off cleanup.
+
+## Key result
+
+Consolidated the group's product portfolio from 4,600 to 1,200 across 19 legal entities — preserving profitability, cutting time-to-market threefold, and standardizing a product-management methodology across the whole holding.

--- a/_case_studies/retail-platform-consolidation.md
+++ b/_case_studies/retail-platform-consolidation.md
@@ -1,0 +1,43 @@
+---
+layout: case
+title: "Core retail platform roadmap after M&A"
+client_alt: "Major European retail group"
+endeavour_id: "24.05"
+engagement_type: "FIX"
+order: 2
+period: "Dec 2022 – Feb 2023"
+role: "Enterprise Architect"
+teaser: "A capability-based roadmap that made post-merger retain / rationalize / replace trade-offs explicit — optimizing investment by removing functional duplication."
+seo_title: "Post-M&A core retail platform roadmap for a major European retail group"
+description: "A capability-based core-retail-platform roadmap that made post-merger consolidation trade-offs explicit — enabling retain / rationalize / replace decisions and optimizing IT investment across banners and regions."
+keywords: "Post-Merger Integration, M&A, Retail Platform, Capability-Based Roadmap, Application Rationalization, Omnichannel, Enterprise Architecture"
+lang: en
+---
+
+## Context
+
+A major European retail group, with an EU/US footprint built through repeated transformations, mergers, and acquisitions, had accumulated a complex and duplicated retail and IT landscape. Platform ownership was unclear, the same capabilities existed several times over across banners and regions, and omnichannel growth now depended on a decision the group had been deferring: **what to standardize centrally, and what to leave local.**
+
+The honest tension was that both extremes were wrong. "One platform for everything" is rarely realistic in a post-merger environment with legitimate banner and regional differences. But leaving everything local locks in duplicated spend and an inconsistent customer experience. The group needed a direction credible enough to drive real retain / rationalize / replace decisions, yet flexible enough to respect organizational and sequencing realities.
+
+## Approach
+
+I started from **business capability, not systems**. Through discovery workshops and capability assessments across business and IT, I mapped application functions to the business capabilities they served — which is what makes overlaps and gaps visible instead of arguable.
+
+That capability view became the spine of the roadmap:
+
+- **Expose duplication objectively.** Where multiple applications delivered the same capability, the map showed it — turning "we think there's overlap" into a documented, decision-ready picture.
+- **Frame the trade-offs explicitly.** Each capability could be retained, rationalized, or replaced; the roadmap attached the reasoning and the cost of duplication to each choice rather than asserting a target end-state.
+- **Sequence for momentum.** The path was structured for incremental convergence — reducing duplication step by step while preserving delivery momentum, so the programme did not have to stall the business to make progress.
+
+The deliverable was a structured strategic plan: specific enough to drive platform decisions, flexible enough to survive contact with organizational reality.
+
+## Outcome
+
+- **A clear, defensible basis for retain / rationalize / replace decisions** across the core retail platform.
+- **Optimized IT investment** by removing functional duplication — spend directed at capabilities that converge rather than at parallel systems doing the same job.
+- **Support for omnichannel growth and operational efficiency**, with consolidation trade-offs made explicit so leadership could align on what converges, when, and why.
+
+## Key result
+
+Structured a capability-based core-retail-platform roadmap that made post-M&A consolidation trade-offs explicit — optimizing investment and avoiding functional duplication across banners and regions.

--- a/_case_studies/subscription-business-model.md
+++ b/_case_studies/subscription-business-model.md
@@ -1,0 +1,46 @@
+---
+layout: case
+title: "From product sales to a subscription business"
+client_alt: "European industrial equipment manufacturer"
+endeavour_id: "24.08"
+engagement_type: "BUILD"
+order: 3
+period: "Mar 2024 – Jun 2024"
+role: "Enterprise Architect (solo engagement)"
+teaser: "The subscription-management blueprint that moved a manufacturer from one-time equipment sales to recurring service revenue — bridging CRM, subscription, and ERP into one order-to-quote flow."
+seo_title: "Subscription business-model transformation for an industrial equipment manufacturer"
+description: "An architecture-first subscription-management blueprint that enabled a European industrial equipment manufacturer to shift from one-time equipment sales to recurring service revenue — bridging CRM, subscription, and ERP into a single order-to-quote flow."
+keywords: "Business Model Transformation, Subscription Management, Lead-to-Cash, Enterprise Architecture, CRM ERP Integration, Vendor Selection, Manufacturing"
+lang: en
+---
+
+## Context
+
+A European industrial equipment manufacturer faced a strategic imperative to move beyond its traditional model of one-time equipment sales. The market was shifting toward service-based offerings, and capturing recurring revenue through subscriptions required more than a new feature — it required a new operating model.
+
+Underneath the strategic question sat an architectural one. Any subscription solution had to bridge the customer-facing CRM, where orders originate, and the back-end ERP, where billing, revenue recognition, and fulfilment live — through a new subscription layer handling flexible pricing, packaging, and contract lifecycle. The existing CRM and ERP were disconnected for this purpose: there was no shared order-to-quote flow for subscriptions, and vendors were already pitching feature-rich products into that gap.
+
+## Approach
+
+I held a firm line: **capability before system.** Three live tensions framed the engagement — quick implementation vs. a comprehensive solution, greenfield vs. brownfield, and buy vs. build. Leadership wanted the robust, integrated, buy path, which made architecture-first sequencing essential to make the vendor decision well rather than under marketing pressure.
+
+The work ran across five layers, delivered solo within a four-month window:
+
+1. **Landscape understanding.** Surveyed the current architecture, documented business rules and constraints, identified CRM and ERP integration touchpoints, and analysed capability gaps.
+2. **Stakeholder alignment.** Interviews across sales, finance, operations, and IT — each holding a local view — to surface conflicting priorities and a resolution strategy. The blueprint needed a global view none of them had alone.
+3. **Capability design.** Current-state (equipment-sales) and future-state (subscription) capability maps, identifying the new capabilities required — contract lifecycle, recurring billing, revenue recognition, dynamic pricing — and the dependencies between them.
+4. **Solution blueprint.** Data models for subscription contracts, pricing, and billing; integration patterns for CRM ↔ subscription ↔ ERP; and the workflows for a single order-to-quote flow.
+5. **Implementation strategy.** A prioritized, phased roadmap and a **vendor-selection framework anchored on architectural fit, not feature checklists** — then staying into early implementation to validate the blueprint against real build-time requirements.
+
+The accepted trade-off: a comprehensive blueprint took longer than a quick fix, but the architectural clarity made every subsequent decision — vendor, integration design, sequencing — cleaner and cheaper.
+
+## Outcome
+
+- **Strategic clarity** on what the subscription business model actually required architecturally — not just which product to buy.
+- **A vendor-selection foundation** built on architectural-fit criteria, avoiding the costly mistake of choosing a solution that doesn't fit the operating model.
+- **An integration design** that prevented the new subscription system from becoming an isolated silo, keeping it operationally coherent with CRM and ERP.
+- **A blueprint validated under build pressure** — participation in early development confirmed the architecture held up against emerging requirements.
+
+## Key result
+
+Designed the subscription-management blueprint that enabled the manufacturer to transition from an equipment-sales business to a subscription and service business — bridging CRM, subscription, and ERP into a single order-to-quote flow.

--- a/_config.yml
+++ b/_config.yml
@@ -86,3 +86,10 @@ exclude:
 collections:
   projects:
     output: false
+  # Featured anchor case studies — each gets its own URL at /cases/:name/.
+  # Source content is the sanitized projection of the private endeavours base
+  # (Layer 2). This public repo (Layer 3) carries descriptors only — no real
+  # client names, no internal project codes.
+  case_studies:
+    output: true
+    permalink: /cases/:name/

--- a/_data/other_engagements.yml
+++ b/_data/other_engagements.yml
@@ -1,0 +1,202 @@
+# Collapsed "Other engagements" list for /cases/.
+# One-line credibility summaries only — the three featured studies live as their
+# own pages in the _case_studies collection.
+#
+# Source: the sanitized projection of the private endeavours base. This public
+# repo carries descriptors only — no real client names, no internal project
+# codes. Ordered most-recent first.
+
+- period: "2025"
+  industry: "Oil & gas"
+  client: "Major oil & gas company in the Middle East"
+  outcome: "Compressed a compensation-planning cycle from 11 weeks to 1–2 weeks (10×) via an AI-enabled target operating model and ready-to-implement AI-agent specifications."
+
+- period: "2025"
+  industry: "Financial services"
+  client: "Bank and payment-systems integrator"
+  outcome: "Aligned the enterprise architecture for a national-scale payment system — prioritizing the initiative portfolio and fixing a technology direction so delivery could start without re-alignment."
+
+- period: "2025"
+  industry: "AI R&D"
+  client: "Internal AI proof-of-concept"
+  outcome: "Built a multi-agent + RAG proof-of-concept demonstrating 5× compression of enterprise-architecture cycles; demoed to a vertically integrated oil & gas company and progressed to implementation negotiation."
+
+- period: "2024–25"
+  industry: "Oil & gas"
+  client: "Major oil & gas company in the Middle East"
+  outcome: "Root-caused recurring loyalty-platform outages across a fuel-retail network and delivered a prioritized resilience roadmap that restored operational stability — in a three-month engagement."
+
+- period: "2024–25"
+  industry: "Telecom"
+  client: "National telecommunications operator"
+  outcome: "Restructured the product-domain architecture (Product / Offer / Bundle / Catalog separation, flexible capability model) — enabling the move from a telecom-only catalogue to a multi-service marketplace including partner products."
+
+- period: "2023–24"
+  industry: "Manufacturing"
+  client: "European industrial equipment manufacturer"
+  outcome: "Framed an MVP-scoped authorization-cockpit roadmap and capability map that enabled a cost-effective vendor selection and a controlled build plan under tight time pressure."
+
+- period: "2023"
+  industry: "Telecom"
+  client: "National telecommunications operator"
+  outcome: "Designed the target-state information architecture and phased roadmap for the transition from a single-service telecom operator to a multi-service digital marketplace (eHealth, FinTech, Cloud)."
+
+- period: "2022"
+  industry: "IT services"
+  client: "Global IT services and consulting firm"
+  outcome: "Structured a governed profile-storage capability and integrity-first migration that operationalized a unified-profile concept, giving consuming systems a single, stable profile contract."
+
+- period: "2022"
+  industry: "IT services"
+  client: "Global IT services and consulting firm"
+  outcome: "Defined a centralized permission engine for role- and resource-based access, replacing scattered per-system access logic with one auditable, governed capability."
+
+- period: "2022"
+  industry: "IT services"
+  client: "Global IT services and consulting firm"
+  outcome: "Framed a single enterprise contact-profile concept — a shared identity contract — that became the foundation for four downstream initiatives and cut duplicated rework."
+
+- period: "2021–22"
+  industry: "IT services"
+  client: "Global IT services and consulting firm"
+  outcome: "Structured the people-profile architecture for an internal HR-management initiative across 58 countries — saving hundreds of person-hours per month while ensuring data-privacy compliance."
+
+- period: "2021"
+  industry: "Aviation IT"
+  client: "IT subsidiary of a national aviation hub"
+  outcome: "Framed the enterprise IT strategy as Head of IT Strategy — a cohesive strategy replacing fragmented local plans, an EA framework for decisions, and vendor selections anchored on strategic fit rather than feature checklists."
+
+- period: "2021"
+  industry: "Aviation IT"
+  client: "National top-2 aviation hub"
+  outcome: "Led a seven-month, enterprise-architecture-driven reorganization of the IT subsidiary — TOGAF-based strategy, Agile delivery, and an external-revenue capability that broke dependence on a single internal customer."
+
+- period: "2019–21"
+  industry: "Aviation"
+  client: "National top-2 aviation hub"
+  outcome: "Restructured the annual enterprise strategy as a risk-management discipline — a comprehensive threat assessment and response plans that proved critical when 2020 pandemic scenarios activated."
+
+- period: "2019"
+  industry: "Aviation IT"
+  client: "IT subsidiary of a national aviation hub"
+  outcome: "Repositioned the IT subsidiary from an internal-only service provider into a dual-model business with external revenue — securing its sustainability through the pandemic-era aviation revenue collapse."
+
+- period: "2018"
+  industry: "Telecom"
+  client: "Large national telecommunications operator"
+  outcome: "Cut storage 15% and report-preparation time 4–5× by diagnosing a corporate data warehouse's organisational root causes and sequencing a phased recovery around named data owners."
+
+- period: "2017–19"
+  industry: "Telecom"
+  client: "Large national telecommunications operator"
+  outcome: "Established a closed-loop loyalty-effectiveness methodology that lets the program be managed on incremental impact rather than points issued."
+
+- period: "2017–19"
+  industry: "Telecom"
+  client: "Large national telecommunications operator"
+  outcome: "Designed a three-layer data-management-platform architecture giving the organization a repeatable way to onboard data and turn it into governed products."
+
+- period: "2017–19"
+  industry: "Telecom"
+  client: "Large national telecommunications operator"
+  outcome: "Designed an inter-operator settlement architecture on an explicit event-and-obligation model — projected to save thousands of man-hours a year and cut error-driven losses."
+
+- period: "2017–19"
+  industry: "Telecom"
+  client: "Large national telecommunications operator"
+  outcome: "Cut corporate accounts receivable ~3× by replacing manual debtor reconciliation with a governed, traceable, multi-channel notification service."
+
+- period: "2017–19"
+  industry: "Telecom"
+  client: "Large national telecommunications operator"
+  outcome: "Replaced broadcast B2B messaging with a governed, segment-based communications capability across 1M+ corporate clients — encoding approval gates and segmentation into the platform."
+
+- period: "2017–19"
+  industry: "Telecom"
+  client: "Large national telecommunications operator"
+  outcome: "Stood up a Data Lab as an outcome-accountable product function — turning underused behavioural data on 30M+ subscribers into a repeatable capability behind targeting, recommendations, and monetisation."
+
+- period: "2017–19"
+  industry: "Telecom & media"
+  client: "Large national company"
+  outcome: "Established an EA baseline (39+ documented components) and a TOGAF-based roadmap that converted a broad growth ambition into a sequenced, dependency-aware set of decisions."
+
+- period: "2016–18"
+  industry: "Oil & gas"
+  client: "Major national oil company"
+  outcome: "Won a competitive enterprise data-lake tender by reframing the platform as a governed, staged capability and proving it with a functional demo and a defendable architecture."
+
+- period: "2016"
+  industry: "Telecom & media"
+  client: "Large national company"
+  outcome: "Delivered a defensible storage decision via three lifecycle-aligned options with explicit trade-offs — avoiding over-provisioning while charting a phased path to independent analytics storage."
+
+- period: "2016–18"
+  industry: "Telecom & media"
+  client: "Large national company"
+  outcome: "Re-established data-product boundaries and ownership across the analytics layer — a target schema and documentation package that made every subsequent report and change request faster and lower-risk."
+
+- period: "2016–18"
+  industry: "Telecom & media"
+  client: "Large national company"
+  outcome: "Stood up a nationwide traffic-analytics and targeting platform that converted unmonetised behavioural data into a new advertising revenue line, with 95%+ subscriber-matching accuracy."
+
+- period: "2015–18"
+  industry: "Financial services"
+  client: "Major private pension fund"
+  outcome: "Structured a governed omnichannel communication system — hundreds of thousands of messages per week, tenfold faster preparation, and event mailings compressed from two weeks to one day."
+
+- period: "2015"
+  industry: "Retail"
+  client: "Major national retail group"
+  outcome: "Framed two tender-ready architecture options for retail climate-equipment monitoring with a quantified 10% electricity-cost reduction — moving from a vague aspiration to a ready-to-procure decision."
+
+- period: "2015–17"
+  industry: "Mobility"
+  client: "Car-sharing service"
+  outcome: "Led the greenfield build of a car-sharing platform from concept to production launch in 20 months — IoT-integrated fleet management on AWS with iOS and Android apps."
+
+- period: "2015–19"
+  industry: "Fuel retail"
+  client: "Gas station retail network"
+  outcome: "Architected and sequenced a fuel-station management platform replacement — full integration and a continuity-first migration that preserved revenue-generating operations throughout."
+
+- period: "2012–15"
+  industry: "Fuel-retail technology"
+  client: "Global technology supplier for banking and retail"
+  outcome: "Delivered an independent architecture audit and a complete, standards-aligned documentation set for a live fuel-retail management platform — converting undocumented dependencies into a defensible record."
+
+- period: "2012–15"
+  industry: "Healthcare & government"
+  client: "Federal healthcare and biomedical agency"
+  outcome: "Delivered a production medical analytics system consolidating heterogeneous health data into a single, traceable basis for performance forecasting and training decisions."
+
+- period: "2012–15"
+  industry: "Oil & gas retail"
+  client: "Major national oil company"
+  outcome: "Grew a retail loyalty program from 1M to 4.5M participants (4.5×) by designing a centralized platform that turned point accounting into a measurable, governed customer-engagement capability."
+
+- period: "2012–15"
+  industry: "Oil & gas retail"
+  client: "Major national oil company"
+  outcome: "Replaced paper fuel vouchers with a cashless corporate-card platform for 70,000+ clients — cutting reconciliation 6× and fraud losses 10× by building control and traceability into the payment lifecycle."
+
+- period: "2008–10"
+  industry: "Telecom"
+  client: "Subsidiary of a national telecommunications operator"
+  outcome: "Cut the budget-planning cycle from 6 months to 2 (3×) by standardizing financial definitions and replacing manual consolidation with an automated, auditable control system."
+
+- period: "2008–10"
+  industry: "Telecom"
+  client: "Subsidiary of a national telecommunications operator"
+  outcome: "Deployed integrated accounting and trade management across all legal entities — a unified, transparent reporting baseline for 50+ branches supporting the pre-sale transparency program."
+
+- period: "2008–10"
+  industry: "Telecom"
+  client: "Subsidiary of a national telecommunications operator"
+  outcome: "Introduced a single payroll and motivation system across 50+ branches, integrated with budgeting, and launched an HR platform for 50+ users as part of the enterprise-wide pre-sale transformation."
+
+- period: "2008–10"
+  industry: "Telecom"
+  client: "Subsidiary of a national telecommunications operator"
+  outcome: "Implemented an ERP consolidation layer for finance, trade, payroll, and budgeting — enabling transparent management reporting and stronger controllability ahead of acquisition."

--- a/_includes/highlights.html
+++ b/_includes/highlights.html
@@ -1,9 +1,10 @@
 {%- comment -%}
-  Shared block of three anchor case outcomes.
-  Used on the home page ("Selected outcomes") and on cases.md ("Highlights").
+  Shared block of three anchor case outcomes — the three Featured engagements.
+  Used on the home page ("Selected outcomes"); the /cases/ index renders the same
+  three as linked teaser cards from the case_studies collection.
   Kept in one place so numbers and phrasing stay consistent across the site.
   The calling page provides its own heading and surrounding context.
 {%- endcomment -%}
 - **National top-2 aviation hub.** Product portfolio reduced from 4,600 to 1,200 items and time-to-market cut threefold — by rebuilding classification, lifecycle rules, and governance across 19 legal entities.
-- **Fuel retail with over 70,000 B2B counterparties.** Reconciliation time cut 6× and fraud-related losses cut 10× — by replacing paper-coupon settlements with a cashless platform and architecting the surrounding governance.
-- **Global IT services firm, approximately 68,000 employees.** 80% of HR inquiries across 12 processes resolved without human intervention, 99% answer accuracy, response times from days to minutes — by architecting the HR assistant and its knowledge and integration layer.
+- **Major European retail group.** A post-merger core-retail-platform roadmap that made retain / rationalize / replace trade-offs explicit — optimizing IT investment by removing functional duplication across banners and regions.
+- **European industrial equipment manufacturer.** A subscription-management blueprint that moved the business from one-time equipment sales to recurring service revenue — bridging CRM, subscription, and ERP into a single order-to-quote flow.

--- a/_layouts/case.html
+++ b/_layouts/case.html
@@ -1,0 +1,67 @@
+---
+layout: default
+---
+
+<article class="case-study">
+
+  <p class="case-back"><a href="/cases/">← All cases</a></p>
+
+  <header class="case-header">
+    {% if page.engagement_type %}<span class="case-tag">{{ page.engagement_type }}</span>{% endif %}
+    <h1 class="case-title">{{ page.title | escape }}</h1>
+    <p class="case-client">{{ page.client_alt | escape }}</p>
+    <dl class="case-facts">
+      {% if page.period %}<div><dt>Period</dt><dd>{{ page.period | escape }}</dd></div>{% endif %}
+      {% if page.role %}<div><dt>Role</dt><dd>{{ page.role | escape }}</dd></div>{% endif %}
+    </dl>
+  </header>
+
+  <div class="case-body">
+    {{ content }}
+  </div>
+
+  <footer class="case-footer">
+    <p><a href="/cases/">← Back to all cases</a></p>
+    <p class="case-cta"><a href="https://calendar.app.google/YwmXZytfSQ2qWX4Z7">→ Book a 30-min intro call</a> to talk through a similar decision.</p>
+  </footer>
+
+</article>
+
+<style>
+  .case-study { max-width: 760px; }
+  .case-back { font-size: 0.9em; margin-bottom: 10px; }
+  .case-header { border-bottom: 2px solid #eee; padding-bottom: 18px; margin-bottom: 24px; }
+  .case-tag {
+    display: inline-block;
+    font-size: 0.72em;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #007bff;
+    border: 1px solid #007bff;
+    border-radius: 4px;
+    padding: 2px 8px;
+    margin-bottom: 12px;
+  }
+  .case-title { margin: 6px 0 4px; font-size: 1.9em; line-height: 1.2; }
+  .case-client { font-size: 1.05em; color: #495057; font-weight: 600; margin: 0 0 14px; }
+  .case-facts { display: flex; flex-wrap: wrap; gap: 8px 32px; margin: 0; }
+  .case-facts div { margin: 0; }
+  .case-facts dt {
+    font-size: 0.72em; text-transform: uppercase; letter-spacing: 0.05em;
+    color: #6c757d; font-weight: 600; margin: 0;
+  }
+  .case-facts dd { margin: 2px 0 0; color: #212529; }
+  .case-body h2 {
+    font-size: 1.2em; color: #212529; margin-top: 28px;
+    padding-bottom: 6px; border-bottom: 1px solid #f1f3f5;
+  }
+  .case-body p, .case-body li { line-height: 1.65; color: #333; }
+  .case-footer { border-top: 1px solid #eee; margin-top: 36px; padding-top: 16px; }
+  .case-cta { font-weight: 600; }
+
+  @media (max-width: 600px) {
+    .case-title { font-size: 1.5em; }
+    .case-facts { gap: 8px 20px; }
+  }
+</style>

--- a/cases.md
+++ b/cases.md
@@ -2,13 +2,13 @@
 layout: page
 title: "Cases"
 seo_title: "Cases | Enterprise Architecture & Technology Advisory"
-description: "Selected engagements in enterprise architecture, technology strategy, and transformation — across aviation, energy, financial services, telecom, and IT services. Filter by industry, role, and functional domain."
+description: "Selected engagements in enterprise architecture, technology strategy, and transformation — across aviation, retail, manufacturing, energy, telecom, and financial services. Three detailed studies plus a full track record."
 keywords: "Enterprise Architecture Cases, Transformation Case Studies, Reorganization, M&A Integration, Cost Optimization, AI Adoption, Digital Transformation Portfolio"
 lang: en
 permalink: /cases/
 ---
 
-Engagements from my practice, grouped around the kinds of decisions they involved — not the tools or frameworks used. Each card opens to a structured view: context, the decision challenge, constraints and trade-offs, the architectural or strategic perspective applied, and the outcome.
+Engagements from my practice, grouped around the kinds of decisions they involved — not the tools or frameworks used.
 
 Most cases fall into one of two patterns:
 
@@ -17,275 +17,128 @@ Most cases fall into one of two patterns:
 
 In practice, most engagements sit on the boundary between the two.
 
-Use the filters below to narrow by industry, role, or functional domain.
-
 **[→ Book a 30-min intro call](https://calendar.app.google/YwmXZytfSQ2qWX4Z7)**
 
 ---
 
-## Highlights
+## Featured engagements
 
-A few engagements that illustrate the type of outcomes this work tends to produce:
+Three studies that show how the work plays out end to end — the decision, the trade-offs, and the outcome.
 
-{% include highlights.html %}
-
-The full list, with filters by industry, role, and functional domain, is below.
-
----
-
-<style>
-  /* Filter Container */
-  .filter-section {
-    margin-bottom: 30px;
-    background: #f8f9fa;
-    padding: 20px;
-    border-radius: 8px;
-    border: 1px solid #e9ecef;
-  }
-  
-  .filter-group {
-    margin-bottom: 15px;
-  }
-  
-  .filter-group:last-child {
-    margin-bottom: 0;
-  }
-
-  .filter-label {
-    font-weight: 600;
-    font-size: 0.85em;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: #6c757d;
-    margin-bottom: 8px;
-    display: block;
-  }
-
-  /* Filter Buttons */
-  .filter-btn {
-    background: white;
-    border: 1px solid #ced4da;
-    border-radius: 20px;
-    padding: 5px 12px;
-    font-size: 0.85em;
-    margin: 0 5px 5px 0;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    color: #495057;
-  }
-
-  .filter-btn:hover {
-    background: #e9ecef;
-    border-color: #adb5bd;
-  }
-
-  .filter-btn.active {
-    background: #007bff;
-    color: white;
-    border-color: #007bff;
-  }
-
-  .filter-btn.clear-all {
-    background: #dc3545;
-    color: white;
-    border-color: #dc3545;
-  }
-
-  /* Project Cards */
-  .project-list {
-    display: flex;
-    flex-direction: column;
-    gap: 15px;
-  }
-
-  .project-card {
-    border: 1px solid #dee2e6;
-    border-radius: 6px;
-    overflow: hidden;
-    background: white;
-    transition: box-shadow 0.2s;
-  }
-  
-  .project-card:hover {
-    box-shadow: 0 4px 10px rgba(0,0,0,0.05);
-  }
-
-  .project-card[hidden] {
-    display: none;
-  }
-
-  .project-summary {
-    padding: 15px;
-    cursor: pointer;
-    list-style: none; /* Hide default triangle */
-    background: #fff;
-    position: relative;
-  }
-
-  .project-summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .project-summary h3 {
-    margin: 0;
-    font-size: 1.1em;
-    color: #212529;
-    padding-right: 30px;
-  }
-
-  .project-meta {
-    font-size: 0.85em;
-    color: #6c757d;
-    margin-top: 5px;
-  }
-
-  .project-content {
-    border-top: 1px solid #f1f3f5;
-    padding: 20px;
-    background: #fff;
-  }
-  
-  .project-content h1 { font-size: 1.5em; border-bottom: 2px solid #eee; padding-bottom: 10px; }
-  .project-content h2 { font-size: 1.2em; color: #495057; margin-top: 20px; }
-  .project-content p { color: #333; line-height: 1.6; }
-
-  /* Plus icon for summary */
-  .project-summary::after {
-    content: '+';
-    position: absolute;
-    right: 20px;
-    top: 50%;
-    transform: translateY(-50%);
-    font-size: 1.5em;
-    color: #ced4da;
-    font-weight: 300;
-  }
-
-  details[open] .project-summary::after {
-    content: '-';
-  }
-  
-  .project-count-label {
-    font-size: 0.9em;
-    color: #6c757d;
-    margin-bottom: 10px;
-  }
-</style>
-
-<div class="filter-section">
-  <!-- Reset -->
-  <div style="margin-bottom: 15px;">
-    <button class="filter-btn clear-all" onclick="filterProjects('all')">Reset Filters</button>
-    <span id="count-display" style="margin-left: 10px; font-size: 0.9em; color: #666;">Showing all projects</span>
-  </div>
-
-  <div class="filter-row">
-    <!-- Industry -->
-    <div class="filter-group">
-      <span class="filter-label">Industry</span>
-      {% assign industries = site.projects | map: "client_side_industry" | flatten | uniq | sort %}
-      {% for item in industries %}
-        <button class="filter-btn" data-filter-type="industry" data-value="{{ item }}" onclick="toggleFilter(this, 'industry', '{{ item }}')">{{ item }}</button>
-      {% endfor %}
-    </div>
-
-    <!-- Functional Domain -->
-    <div class="filter-group">
-      <span class="filter-label">Functional Domain</span>
-      {% assign functionals = site.projects | map: "functional" | flatten | uniq | sort %}
-      {% for item in functionals %}
-        <button class="filter-btn" data-filter-type="functional" data-value="{{ item }}" onclick="toggleFilter(this, 'functional', '{{ item }}')">{{ item | replace: '-', ' ' }}</button>
-      {% endfor %}
-    </div>
-
-    <!-- Role -->
-    <div class="filter-group">
-      <span class="filter-label">Role</span>
-      {% assign roles = site.projects | map: "roles" | flatten | uniq | sort %}
-      {% for item in roles %}
-        <button class="filter-btn" data-filter-type="role" data-value="{{ item }}" onclick="toggleFilter(this, 'role', '{{ item }}')">{{ item | replace: '-', ' ' | capitalize }}</button>
-      {% endfor %}
-    </div>
-  </div>
-</div>
-
-<div class="project-list" id="project-list">
-  {% for project in site.projects reversed %}
-    <details class="project-card"
-             data-industry="{{ project.client_side_industry | join: ',' }}"
-             data-functional="{{ project.functional | join: ',' }}"
-             data-role="{{ project.roles | join: ',' }}">
-      <summary class="project-summary">
-        <h3>{{ project.title }}</h3>
-        <div class="project-meta">
-          <strong>Industry:</strong> {{ project.client_side_industry | join: ', ' }} |
-          <strong>Role:</strong> {{ project.roles | join: ', ' | replace: '-', ' ' | capitalize }}
-        </div>
-      </summary>
-      <div class="project-content">
-        {{ project.content | markdownify }}
-      </div>
-    </details>
+<div class="featured-cases">
+  {% assign featured = site.case_studies | sort: "order" %}
+  {% for case in featured %}
+  <a class="featured-card" href="{{ case.url | relative_url }}">
+    <span class="featured-tag">{{ case.engagement_type }}</span>
+    <h3>{{ case.title | escape }}</h3>
+    <p class="featured-client">{{ case.client_alt | escape }}</p>
+    <p class="featured-meta">{{ case.period | escape }}</p>
+    <p class="featured-teaser">{{ case.teaser | escape }}</p>
+    <span class="featured-link">Read the case →</span>
+  </a>
   {% endfor %}
 </div>
 
-<script>
-  let activeFilters = {
-    industry: [],
-    functional: [],
-    role: []
-  };
+---
 
-  function toggleFilter(btn, type, value) {
-    // Toggle active class
-    btn.classList.toggle('active');
-    
-    // Update state
-    const index = activeFilters[type].indexOf(value);
-    if (index === -1) {
-      activeFilters[type].push(value);
-    } else {
-      activeFilters[type].splice(index, 1);
-    }
-    
-    applyFilters();
+## Other engagements
+
+A condensed view of the broader track record — one line each, most recent first.
+
+<details class="other-engagements">
+  <summary>Show the full list ({{ site.data.other_engagements | size }} engagements)</summary>
+  <ul class="engagement-list">
+    {% for e in site.data.other_engagements %}
+    <li>
+      <span class="eng-period">{{ e.period }}</span>
+      <span class="eng-sector">{{ e.industry }} · {{ e.client }}</span>
+      <span class="eng-outcome">{{ e.outcome }}</span>
+    </li>
+    {% endfor %}
+  </ul>
+</details>
+
+<p class="cases-note" markdown="1">
+Most engagements are rendered with neutral, industry-level descriptors rather than client names. Where you need specifics for a relevant decision, [ask my assistant](javascript:void(0)) or [book a call](https://calendar.app.google/YwmXZytfSQ2qWX4Z7).
+</p>
+
+<style>
+  /* Featured cards */
+  .featured-cases {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 18px;
+    margin: 24px 0;
   }
-
-  function filterProjects(action) {
-    if (action === 'all') {
-      // Clear state
-      activeFilters = { industry: [], functional: [], role: [] };
-      // Remove all active classes
-      document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
-    }
-    applyFilters();
+  .featured-card {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    padding: 20px;
+    background: #fff;
+    text-decoration: none;
+    color: inherit;
+    transition: box-shadow 0.2s, transform 0.2s, border-color 0.2s;
   }
-
-  function applyFilters() {
-    const cards = document.querySelectorAll('.project-card');
-    let visibleCount = 0;
-
-    cards.forEach(card => {
-      const cardInd = card.dataset.industry.split(',');
-      const cardFunc = card.dataset.functional.split(',');
-      const cardRole = card.dataset.role.split(',');
-
-      // Check if card matches ALL active filter categories (AND logic between categories, OR within category)
-      const matchIndustry = activeFilters.industry.length === 0 || activeFilters.industry.some(f => cardInd.includes(f));
-      const matchFunc = activeFilters.functional.length === 0 || activeFilters.functional.some(f => cardFunc.includes(f));
-      const matchRole = activeFilters.role.length === 0 || activeFilters.role.some(f => cardRole.includes(f));
-
-      if (matchIndustry && matchFunc && matchRole) {
-        card.removeAttribute('hidden');
-        visibleCount++;
-      } else {
-        card.setAttribute('hidden', '');
-      }
-    });
-
-    // Update counter
-    const total = cards.length;
-    const text = visibleCount === total ? `Showing all ${total} projects` : `Showing ${visibleCount} of ${total} projects`;
-    document.getElementById('count-display').innerText = text;
+  .featured-card:hover {
+    box-shadow: 0 6px 18px rgba(0,0,0,0.08);
+    transform: translateY(-2px);
+    border-color: #adb5bd;
   }
-</script>
+  .featured-tag {
+    align-self: flex-start;
+    font-size: 0.7em;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #007bff;
+    border: 1px solid #007bff;
+    border-radius: 4px;
+    padding: 2px 8px;
+    margin-bottom: 12px;
+  }
+  .featured-card h3 { margin: 0 0 6px; font-size: 1.15em; line-height: 1.3; color: #212529; }
+  .featured-client { margin: 0 0 2px; font-weight: 600; color: #495057; font-size: 0.95em; }
+  .featured-meta { margin: 0 0 12px; font-size: 0.82em; color: #6c757d; }
+  .featured-teaser { margin: 0 0 16px; font-size: 0.92em; line-height: 1.55; color: #333; flex-grow: 1; }
+  .featured-link { font-weight: 600; color: #007bff; font-size: 0.9em; }
+
+  /* Other engagements list */
+  .other-engagements {
+    border: 1px solid #e9ecef;
+    border-radius: 8px;
+    background: #f8f9fa;
+    padding: 0 18px;
+    margin: 16px 0;
+  }
+  .other-engagements summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: #495057;
+    padding: 16px 0;
+    list-style: none;
+  }
+  .other-engagements summary::-webkit-details-marker { display: none; }
+  .other-engagements summary::before { content: "▸ "; color: #adb5bd; }
+  .other-engagements[open] summary::before { content: "▾ "; }
+  .engagement-list { list-style: none; margin: 0 0 16px; padding: 0; }
+  .engagement-list li {
+    padding: 12px 0;
+    border-top: 1px solid #e9ecef;
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    gap: 2px 14px;
+    align-items: baseline;
+  }
+  .eng-period { grid-row: span 2; font-size: 0.82em; color: #6c757d; font-weight: 600; }
+  .eng-sector { font-weight: 600; color: #343a40; font-size: 0.9em; }
+  .eng-outcome { grid-column: 2; color: #495057; font-size: 0.9em; line-height: 1.5; }
+  .cases-note { font-size: 0.88em; color: #6c757d; margin-top: 24px; }
+
+  @media (max-width: 600px) {
+    .engagement-list li { grid-template-columns: 1fr; }
+    .eng-period { grid-row: auto; }
+    .eng-outcome { grid-column: 1; }
+  }
+</style>


### PR DESCRIPTION
Restructures `/cases/` from a 44-card filter list into a senior-practitioner shape — **three detailed studies + a collapsed track record** — and aligns the homepage Selected outcomes to match.

Implements strategy issue #395. Do not merge — gating is yours.

## What changed

**New `case_studies` collection** (`output: true`, `permalink: /cases/:name/`) with a dedicated `_layouts/case.html`. Three featured pages, each with four sections (Context / Approach / Outcome / Key result):

| URL | Engagement | Framing |
|---|---|---|
| `/cases/aviation-portfolio-reorganization/` | National top-2 aviation hub | BUILD |
| `/cases/retail-platform-consolidation/` | Major European retail group | FIX (post-M&A) |
| `/cases/subscription-business-model/` | European industrial equipment manufacturer | BUILD |

**`/cases/` index** — three linked teaser cards (Read the case →) + a collapsed `<details>` one-line list of the remaining **39 engagements**, sourced from `_data/other_engagements.yml`. The old 44-card filter UI and `site.projects` render are gone (`site.projects` is now referenced nowhere).

**Homepage Selected outcomes** — the shared `_includes/highlights.html` now carries the same three featured engagements (was: fuel-retail + HR-bot), so home and `/cases/` tell one story.

## Naming / hygiene

- Every rendered surface carries **neutral, industry-level descriptors only** — zero real client names, zero internal project codes. Verified by grep over the touched source files **and** the built `_site/cases/` + `_site/index.html` (zero hits, including the `\b[A-Z]{3,4}-[A-Z]{2,4}\b` code pattern).
- The aviation-hub case is `public` in the canonical base but rendered here with the descriptor "National top-2 aviation hub" — "fully surfaced" means *featured as a full page*, not *real name*, per CLAUDE.md and the real-names ADR.
- Content authored from the **sanitized projection** of the private portfolio base (the same Layer-2 contract #367 will later automate).

## Build

`bundle exec jekyll build` succeeds; all four URLs generate; card links and back-links resolve.

## ⚠️ One residual — for #367, not this PR

`cases.md` no longer references `site.projects`, but the 44 `_projects/*.md` files remain on disk with **leaky filenames** (real names + codes in the path, e.g. `09. Gamm - GAM-CAR5.md`). Their content is clean and they no longer render or appear in `_site/`. Removing them is the **#367 cutover** (explicitly out of scope here) — and must happen before the history nuke (#368) captures a clean `main`.

## ADR

Architectural decision recorded in the strategy hub: vkgeorgia/strategy#398 (`Architecture/vkgeorgia-io/2026-06-27-anchor-case-studies.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)